### PR TITLE
Add config module with basic functionalities

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,10 +3,15 @@ uuid = "e0ebcb34-69ae-4d20-9e42-b33a0f43aa89"
 authors = ["Leandro Ferrado <leferrad@gmail.com> and contributors"]
 version = "0.1.0"
 
+[deps]
+Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
+TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
+
 [compat]
 julia = "1.6.5"
 
 [extras]
+JuliaFormatter = "98e50ef6-434e-11e9-1051-2b60c6c9e899"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]

--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@
 [![Build Status](https://github.com/leferrad/DataWorkstation.jl/actions/workflows/CI.yml/badge.svg?branch=main)](https://github.com/leferrad/DataWorkstation.jl/actions/workflows/CI.yml?query=branch%3Amain) 
 [![Coverage](https://codecov.io/gh/leferrad/DataWorkstation.jl/branch/main/graph/badge.svg)](https://codecov.io/gh/leferrad/DataWorkstation.jl) 
 [![Code Style: Blue](https://img.shields.io/badge/code%20style-blue-4495d1.svg)](https://github.com/invenia/BlueStyle) 
-[![ColPrac: Contributor's Guide on Collaborative Practices for Community Packages](https://img.shields.io/badge/ColPrac-Contributor's%20Guide-blueviolet)](https://github.com/SciML/ColPrac)
 [![Jira](https://badgen.net/badge/icon/jira?icon=jira&label)](https://leferrad.atlassian.net/browse/DWJL)
 
 ## License

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,20 @@
+DataWorkstation.jl Documentation README
+================================
+
+DataWorkstation.jl's documentation is written with [Documenter.jl](https://github.com/JuliaDocs/Documenter.jl). To install it, run the following command in a Julia session:
+
+```julia
+Pkg.add("Documenter")
+```
+
+
+Building the documentation
+--------------------------
+
+The documentation is built using the following command:
+
+```julia
+julia --project=. --color=yes make.jl
+```
+
+The compiled documents can be viewed at `build/index.html`.

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,24 +1,24 @@
 using DataWorkstation
 using Documenter
 
-DocMeta.setdocmeta!(DataWorkstation, :DocTestSetup, :(using DataWorkstation); recursive=true)
+DocMeta.setdocmeta!(
+    DataWorkstation,
+    :DocTestSetup,
+    :(using DataWorkstation);
+    recursive = true,
+)
 
 makedocs(;
-    modules=[DataWorkstation],
-    authors="Leandro Ferrado <leferrad@gmail.com> and contributors",
-    repo="https://github.com/leferrad/DataWorkstation.jl/blob/{commit}{path}#{line}",
-    sitename="DataWorkstation.jl",
-    format=Documenter.HTML(;
-        prettyurls=get(ENV, "CI", "false") == "true",
-        canonical="https://leferrad.github.io/DataWorkstation.jl",
-        assets=String[],
+    modules = [DataWorkstation],
+    authors = "Leandro Ferrado <leferrad@gmail.com> and contributors",
+    repo = "https://github.com/leferrad/DataWorkstation.jl/blob/{commit}{path}#{line}",
+    sitename = "DataWorkstation.jl",
+    format = Documenter.HTML(;
+        prettyurls = get(ENV, "CI", "false") == "true",
+        canonical = "https://leferrad.github.io/DataWorkstation.jl",
+        assets = String[],
     ),
-    pages=[
-        "Home" => "index.md",
-    ],
+    pages = ["Home" => "index.md"],
 )
 
-deploydocs(;
-    repo="github.com/leferrad/DataWorkstation.jl",
-    devbranch="main",
-)
+deploydocs(; repo = "github.com/leferrad/DataWorkstation.jl", devbranch = "develop")

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -6,9 +6,22 @@ CurrentModule = DataWorkstation
 
 Documentation for [DataWorkstation](https://github.com/leferrad/DataWorkstation.jl).
 
+## API Reference
+
+### Index
 ```@index
 ```
 
 ```@autodocs
 Modules = [DataWorkstation]
+Private = false
+Order = [:type, :function]
+```
+
+### Config module
+```@docs
+DataWorkstation.Config.ConfigObject
+DataWorkstation.Config.load_config
+DataWorkstation.Config.parse_config
+DataWorkstation.Config.update_config
 ```

--- a/src/DataWorkstation.jl
+++ b/src/DataWorkstation.jl
@@ -1,6 +1,9 @@
 module DataWorkstation
 
 include("config/Config.jl")
+using .Config
+export ConfigObject, load_config, parse_config, update_config
+
 include("io/IO.jl")
 include("workflows/Workflows.jl")
 

--- a/src/config/Config.jl
+++ b/src/config/Config.jl
@@ -1,5 +1,8 @@
 module Config
 
-# Write your code here.
+export ConfigObject, load_config, parse_config, update_config
+
+include("config_object.jl")
+include("parse.jl")
 
 end

--- a/src/config/config_object.jl
+++ b/src/config/config_object.jl
@@ -7,6 +7,36 @@ Elements in the object being NamedTuple are converted to ConfigObject instances.
 
 # Fields
 - `_nt::NamedTuple`: stores the keys and values for the configuration
+
+# Examples
+```jldoctest
+julia> raw = (;a=1, b=(;c=3, d=4))
+(a = 1, b = (c = 3, d = 4))
+
+julia> cfg = ConfigObject(raw)
+ConfigObject((a = 1, b = ConfigObject((c = 3, d = 4))))
+
+julia> cfg.b
+ConfigObject((c = 3, d = 4))
+
+julia> cfg.b.d
+4
+
+julia> length(cfg)
+2
+
+julia> keys(cfg), values(cfg)
+((:a, :b), (1, ConfigObject((c = 3, d = 4))))
+
+julia> merge(cfg, (;e=5, f=6))
+ConfigObject((a = 1, b = ConfigObject((c = 3, d = 4)), e = 5, f = 6))
+
+julia> cfg == ConfigObject(raw)
+true
+
+julia> collect(cfg)
+(a = 1, b = (c = 3, d = 4))
+```
 """
 struct ConfigObject
     _nt::NamedTuple

--- a/src/config/config_object.jl
+++ b/src/config/config_object.jl
@@ -1,0 +1,49 @@
+@doc raw"""
+    ConfigObject(nt::NamedTuple)
+    ConfigObject(cfg::ConfigObject)
+
+Abstraction to manage configuration values in a program.
+Elements in the object being NamedTuple are converted to ConfigObject instances.
+
+# Fields
+- `_nt::NamedTuple`: stores the keys and values for the configuration
+"""
+struct ConfigObject
+    _nt::NamedTuple
+    ConfigObject(x) = x
+    ConfigObject(nt::NamedTuple) =
+        :_nt in keys(nt) ?
+            throw(KeyError(
+                "Keys of a ConfigObject cannot have a '_nt' entry. Got $(keys(nt))")) :
+            new((; (Symbol(k) => ConfigObject(v) for (k, v) in zip(keys(nt), nt))...))
+    ConfigObject(cfg::ConfigObject) = cfg
+end
+
+# Methods to treat a ConfigObject just like a NamedTuple
+Base.getproperty(cfg::ConfigObject, s::Symbol) = begin
+    s == :_nt ? getfield(cfg, s) :
+    hasproperty(cfg._nt, s) ? getfield(cfg._nt, s) :
+    throw(ErrorException("ConfigObject has no value $(s)"))
+end
+Base.getindex(cfg::ConfigObject, s::Symbol) = getindex(cfg._nt, s)
+Base.hasproperty(cfg::ConfigObject, k::Symbol) = hasproperty(cfg._nt, k)
+Base.propertynames(cfg::ConfigObject) = keys(cfg)
+Base.keys(cfg::ConfigObject) = keys(cfg._nt)
+Base.values(cfg::ConfigObject) = values(cfg._nt)
+Base.iterate(cfg::ConfigObject) = iterate(cfg._nt)
+Base.iterate(cfg::ConfigObject, i) = iterate(cfg._nt, i)
+Base.merge(cfg::ConfigObject, a::NamedTuple) = ConfigObject(merge(cfg._nt, a))
+Base.merge(a::NamedTuple, cfg::ConfigObject) = ConfigObject(merge(a, cfg._nt))
+Base.merge(cfg1::ConfigObject, cfg2::ConfigObject) = ConfigObject(merge(cfg1._nt, cfg2._nt))
+Base.length(cfg::ConfigObject) = length(cfg._nt)
+Base.:(==)(a::ConfigObject, b::ConfigObject) =
+    length(a) == length(b) &&
+    all(p1.first == p2.first && p1.second == p2.second
+        for (p1, p2) in zip(
+            sort(collect(pairs(a._nt)), by=x->x.first),
+            sort(collect(pairs(b._nt)), by=x->x.first)))
+Base.collect(cfg::ConfigObject) = (
+    ; (Symbol(k) => (
+        typeof(v) == ConfigObject ? collect(v) : v
+    )
+    for (k, v) in zip(keys(cfg), values(cfg)))...)

--- a/src/config/parse.jl
+++ b/src/config/parse.jl
@@ -1,0 +1,131 @@
+import TOML
+
+# Regex to identify configuration filenames
+CONFIG_FILE_REGEX = r"\$\((.*?).toml\)"
+
+@doc raw"""
+    parse_config(d::Dict, root::Union{AbstractString, Nothing} = nothing) -> ConfigObject
+    parse_config(s::AbstractString, root) -> Union{ConfigObject, String}
+
+Parse an input to build a ConfigObject instance. If the input is a Dict, the content
+will be converted into entries for a ConfigObject. If some entry contains a string of
+the kind "$(filename.toml)", it is taken as a file to load as a ConfigObject.
+
+# Arguments
+- `d::Dict`: the dict to convert to a ConfigObject instance
+- `s::AbstractString`: when a value is a string with a format like "$(filename.toml)",
+    the file is loaded from that path as a ConfigObject
+- `root::Union{AbstractString, Nothing}=nothing`: in case of loading a file,
+    this is the root for the path to load (optional)
+
+# Returns
+- `ConfigObject`: having the content parsed from the input
+
+# Examples
+```jldoctest
+julia> config_dict = Dict("a" => 1, "b" => Dict("c" => 2, "d" => 3))
+Dict{String, Any} with 2 entries:
+  "b" => Dict("c"=>2, "d"=>3)
+  "a" => 1
+
+julia> parse_config(config_dict)
+ConfigObject((b = ConfigObject((c = 2, d = 3)), a = 1))
+
+julia> using TOML
+
+julia> filename = tempdir() * "/cfg.toml"
+"/tmp/cfg.toml"
+
+julia> open(filename, "w") do io
+    TOML.print(io, config_dict)
+end
+
+julia> parse_config(Dict("cfg" => "\$($(filename))"))
+ConfigObject((cfg = ConfigObject((b = ConfigObject((c = 2, d = 3)), a = 1)),))
+```
+"""
+parse_config(d::Dict, root::Union{AbstractString, Nothing} = nothing) =
+    ConfigObject((; (Symbol(p.first) => parse_config(p.second, root) for p in d)...))
+parse_config(s::AbstractString, root::Union{AbstractString, Nothing} = nothing) = begin
+    m = match(CONFIG_FILE_REGEX, s)
+    if m !== nothing
+        fn = "$(m.captures[1]).toml"
+        return parse_config(TOML.tryparsefile(root * "/" * fn), root)
+    end
+    s
+end
+parse_config(x, root) = x
+
+@doc raw"""
+    load_config(filename, root) -> ConfigObject
+
+Load a file as a ConfigObject instance.
+
+# Arguments
+- `filename::AbstractString`: the path to load to get the configuration content
+- `root::Union{AbstractString, Nothing}`: root for the path to load (optional)
+
+# Returns
+- `ConfigObject`: having the content loaded from the file
+
+# Examples
+```jldoctest
+julia> config_dict = Dict("a" => 1, "b" => Dict("c" => 2, "d" => 3))
+Dict{String, Any} with 2 entries:
+  "b" => Dict("c"=>2, "d"=>3)
+  "a" => 1
+
+julia> using TOML
+
+julia> filename = tempdir() * "/cfg.toml"
+"/tmp/cfg.toml"
+
+julia> open(filename, "w") do io
+    TOML.print(io, config_dict)
+end
+
+julia> load_config(filename)
+ConfigObject((b = ConfigObject((c = 2, d = 3)), a = 1))
+```
+"""
+load_config(
+    filename::AbstractString, root::Union{AbstractString, Nothing} = nothing) = begin
+    root = root === nothing ? dirname(filename) : root
+    parse_config(TOML.parsefile(filename), root)
+end
+
+@doc raw"""
+    update_config(cfg::ConfigObject, entries::NamedTuple) -> ConfigObject
+
+Get a new ConfigObject by updating the content with new entries
+
+# Arguments
+- `cfg::ConfigObject`: configuration instance to updated
+- `entries::NamedTuple`: new entries to put into the configuration instance
+
+# Returns
+- `ConfigObject`: having updated entries
+
+# Examples
+```jldoctest
+julia> raw = (;a=1, b=(;c=3, d=4))
+(a = 1, b = (c = 3, d = 4))
+
+julia> cfg = ConfigObject(raw)
+ConfigObject((a = 1, b = ConfigObject((c = 3, d = 4))))
+
+julia> update_config(cfg, (;e=5, f=6))
+ConfigObject((a = 1, b = ConfigObject((c = 3, d = 4)), e = 5, f = 6))
+```
+"""
+update_config(old, new) = new
+update_config(cfg::ConfigObject, entries::NamedTuple) = begin
+    for (k, v) in zip(keys(entries), entries)
+        if k in keys(cfg)
+            v = update_config(cfg[k], v)
+        end
+        new_entry = (; k => v)
+        cfg = ConfigObject((; cfg..., new_entry...))
+    end
+    return cfg
+end

--- a/src/config/parse.jl
+++ b/src/config/parse.jl
@@ -4,7 +4,7 @@ import TOML
 CONFIG_FILE_REGEX = r"\$\((.*?).toml\)"
 
 @doc raw"""
-    parse_config(d::Dict, root::Union{AbstractString, Nothing} = nothing) -> ConfigObject
+    parse_config(d::Dict, root::AbstractString = "") -> ConfigObject
     parse_config(s::AbstractString, root) -> Union{ConfigObject, String}
 
 Parse an input to build a ConfigObject instance. If the input is a Dict, the content
@@ -15,7 +15,7 @@ the kind "$(filename.toml)", it is taken as a file to load as a ConfigObject.
 - `d::Dict`: the dict to convert to a ConfigObject instance
 - `s::AbstractString`: when a value is a string with a format like "$(filename.toml)",
     the file is loaded from that path as a ConfigObject
-- `root::Union{AbstractString, Nothing}=nothing`: in case of loading a file,
+- `root::AbstractString=""`: in case of loading a file,
     this is the root for the path to load (optional)
 
 # Returns
@@ -37,16 +37,16 @@ julia> filename = tempdir() * "/cfg.toml"
 "/tmp/cfg.toml"
 
 julia> open(filename, "w") do io
-    TOML.print(io, config_dict)
-end
+       TOML.print(io, config_dict)
+       end;
 
 julia> parse_config(Dict("cfg" => "\$($(filename))"))
 ConfigObject((cfg = ConfigObject((b = ConfigObject((c = 2, d = 3)), a = 1)),))
 ```
 """
-parse_config(d::Dict, root::Union{AbstractString, Nothing} = nothing) =
+parse_config(d::Dict, root::AbstractString = "") =
     ConfigObject((; (Symbol(p.first) => parse_config(p.second, root) for p in d)...))
-parse_config(s::AbstractString, root::Union{AbstractString, Nothing} = nothing) = begin
+parse_config(s::AbstractString, root::AbstractString = "") = begin
     m = match(CONFIG_FILE_REGEX, s)
     if m !== nothing
         fn = "$(m.captures[1]).toml"
@@ -54,7 +54,7 @@ parse_config(s::AbstractString, root::Union{AbstractString, Nothing} = nothing) 
     end
     s
 end
-parse_config(x, root) = x
+parse_config(x, root = "") = x
 
 @doc raw"""
     load_config(filename, root) -> ConfigObject
@@ -63,7 +63,7 @@ Load a file as a ConfigObject instance.
 
 # Arguments
 - `filename::AbstractString`: the path to load to get the configuration content
-- `root::Union{AbstractString, Nothing}`: root for the path to load (optional)
+- `root::AbstractString`: root for the path to load (optional)
 
 # Returns
 - `ConfigObject`: having the content loaded from the file
@@ -81,16 +81,16 @@ julia> filename = tempdir() * "/cfg.toml"
 "/tmp/cfg.toml"
 
 julia> open(filename, "w") do io
-    TOML.print(io, config_dict)
-end
+       TOML.print(io, config_dict)
+       end;
 
 julia> load_config(filename)
 ConfigObject((b = ConfigObject((c = 2, d = 3)), a = 1))
 ```
 """
 load_config(
-    filename::AbstractString, root::Union{AbstractString, Nothing} = nothing) = begin
-    root = root === nothing ? dirname(filename) : root
+    filename::AbstractString, root::AbstractString = "") = begin
+    root = root === "" ? dirname(filename) : root
     parse_config(TOML.parsefile(filename), root)
 end
 

--- a/test/config/config_object.jl
+++ b/test/config/config_object.jl
@@ -1,0 +1,63 @@
+
+function test_configobject_constructor()
+    nt = (; a = 1, b = (; c = 2, d = 3))
+    cfg = ConfigObject(nt)
+
+    @test cfg.a == nt.a
+    @test cfg.b isa ConfigObject
+    @test cfg.b.c == nt.b.c
+    @test ConfigObject(cfg) == cfg
+    @test_throws KeyError ConfigObject((;_nt="value_for_not_valid_key"))
+end
+
+function test_configobject_iterable()
+    nt = (; a = 1, b = (; c = 2, d = 3))
+    cfg = ConfigObject(nt)
+
+    @test keys(cfg) == (:a, :b)
+    @test values(cfg) == (1, ConfigObject((; c = 2, d = 3)))
+    @test iterate(cfg) == (1, 2)
+    @test iterate(cfg, 2) == (ConfigObject((; c = 2, d = 3)), 3)
+    @test collect(cfg) == nt
+end
+
+function test_configobject_properties()
+    nt = (; a = 1, b = (; c = 2, d = 3))
+    cfg = ConfigObject(nt)
+
+    @test propertynames(cfg) == keys(nt)
+    @test hasproperty(cfg, :a) === true
+    @test getproperty(cfg, :_nt) == (; a = 1, b = ConfigObject((; c = 2, d = 3)))
+    @test getindex(cfg, :a) == getindex(nt, :a)
+    @test_throws ErrorException getproperty(cfg, :not_valid_property)
+end
+
+function test_configobject_equals()
+    nt1 = (; a = 1, b = (; c = 2, d = 3))
+    nt2 = (; b = (; d = 3, c = 2), a = 1)
+    @test ConfigObject(nt1) == ConfigObject(nt2)
+    @test ConfigObject(nt1) != ConfigObject(nt2.b)
+end
+
+function test_configobject_merge()
+    nt1 = (; a = 1, b = (; c = 2, d = 3))
+    nt2 = (; e = 4, f = (; g = 5, h = 6))
+    cfg1 = ConfigObject(nt1)
+    cfg2 = ConfigObject(nt2)
+
+    @test merge(nt1, cfg2) == ConfigObject((; nt1..., nt2...))
+    @test merge(cfg1, nt2) == ConfigObject((; nt1..., nt2...))
+    @test merge(cfg1, cfg2) == ConfigObject((; nt1..., nt2...))
+end
+
+@testset "config_object.jl" begin
+    @testset "unit" begin
+        @testset "basics" begin
+            test_configobject_constructor()
+            test_configobject_iterable()
+            test_configobject_properties()
+            test_configobject_equals()
+            test_configobject_merge()
+        end
+    end
+end

--- a/test/config/parse.jl
+++ b/test/config/parse.jl
@@ -1,0 +1,53 @@
+using TOML
+
+
+create_temp_config_file(cfg::Dict) = begin
+    fname = tempname() * ".toml"
+    open(fname, "w") do io
+        TOML.print(io, cfg)
+    end
+    return fname
+end
+
+
+function test_parse_config()
+    config_dict = Dict("a" => 1, "b" => Dict("c" => 2, "d" => 3))
+    config_nt = (; a = 1, b = (; c = 2, d = 3))
+    cfg = ConfigObject(config_nt)
+    @test parse_config(config_dict, "") == cfg
+    @test parse_config("not_valid", "") == "not_valid"
+
+    filename = create_temp_config_file(config_dict)
+    root, fname = dirname(filename), basename(filename)
+    escaped_fname = "\$($(fname))"
+    @test parse_config(escaped_fname, root) == cfg
+end
+
+function test_load_config()
+    config_dict = Dict("a" => 1, "b" => Dict("c" => 2, "d" => 3))
+    config_nt = (; a = 1, b = (; c = 2, d = 3))
+    cfg = ConfigObject(config_nt)
+
+    filename = create_temp_config_file(config_dict)
+    root, fname = dirname(filename), basename(filename)
+    @test load_config(joinpath(root, fname), root) == cfg
+    @test load_config(joinpath(root, fname)) == cfg
+end
+
+function test_update_config()
+    config_nt = (; a = 1, b = (; c = 2, d = 3))
+    new_entries = (; a = 2, e = (f = 3, g = 4))
+    cfg = ConfigObject(config_nt)
+
+    @test update_config(cfg, new_entries) == ConfigObject((; config_nt..., new_entries...))
+end
+
+@testset "parse.jl" begin
+    @testset "unit" begin
+        @testset "basics" begin
+            test_parse_config()
+            test_load_config()
+            test_update_config()
+        end
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,10 @@
 using DataWorkstation
+using Logging
 using Test
 
+Logging.disable_logging(Logging.Info)
+
 @testset "DataWorkstation.jl" begin
-    # Write your tests here.
-    @test 1 == 1
+    include("config/config_object.jl")
+    include("config/parse.jl")
 end


### PR DESCRIPTION
This PR is intended to add functionalities for the module `Config.jl`, in order to start handling configuration instances.

More details in the ticket [DWJL-36](https://leferrad.atlassian.net/browse/DWJL-36).

### Summary of changes

- [updated Project.toml](https://github.com/leferrad/DataWorkstation.jl/pull/2/commits/2a5218c4ac978c1b72050c8cf51feae0e9450a9e)
- [improved docs/make.jl](https://github.com/leferrad/DataWorkstation.jl/pull/2/commits/62a899f4e3b8a1bdfea1c32c8892a9f90021721e)
- [added config_object into Config module](https://github.com/leferrad/DataWorkstation.jl/pull/2/commits/b223eaa170ec0ff7bb5b9d21c026c9e82dc59871)
- [updated docstring in config_object.jl](https://github.com/leferrad/DataWorkstation.jl/pull/2/commits/5b5e55630b466a6b78b3e91720fb1ba715ca88f4)
- [added parse.jl for module Config](https://github.com/leferrad/DataWorkstation.jl/pull/2/commits/021765f358c4ef48c254ba822eb9048dd684a12a)
- [updated README.md](https://github.com/leferrad/DataWorkstation.jl/pull/2/commits/7e4a6283f52119dea62386c46aed10ce898b6b86)
- [updated docs](https://github.com/leferrad/DataWorkstation.jl/pull/2/commits/8e0569dd74ca1d24f8244b2cf4e2fa24252a6b3d)